### PR TITLE
Bulk Edit

### DIFF
--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -451,10 +451,12 @@ class PlutoGridCellPosition {
 class PlutoGridSelectingCellPosition {
   final String? field;
   final int? rowIdx;
+  final int? columnIdx;
 
   const PlutoGridSelectingCellPosition({
     this.field,
     this.rowIdx,
+    this.columnIdx,
   });
 
   @override
@@ -463,11 +465,12 @@ class PlutoGridSelectingCellPosition {
         other is PlutoGridSelectingCellPosition &&
             runtimeType == other.runtimeType &&
             field == other.field &&
-            rowIdx == other.rowIdx;
+            rowIdx == other.rowIdx &&
+            columnIdx == other.columnIdx;
   }
 
   @override
-  int get hashCode => Object.hash(field, rowIdx);
+  int get hashCode => Object.hash(field, rowIdx, columnIdx);
 }
 
 class PlutoGridKeyPressed {
@@ -483,6 +486,13 @@ class PlutoGridKeyPressed {
 
     return !(!keysPressed.contains(LogicalKeyboardKey.controlLeft) &&
         !keysPressed.contains(LogicalKeyboardKey.controlRight));
+  }
+
+  bool get meta {
+    final keysPressed = HardwareKeyboard.instance.logicalKeysPressed;
+
+    return !(!keysPressed.contains(LogicalKeyboardKey.metaLeft) &&
+        !keysPressed.contains(LogicalKeyboardKey.metaRight));
   }
 }
 

--- a/lib/src/manager/state/editing_state.dart
+++ b/lib/src/manager/state/editing_state.dart
@@ -20,6 +20,12 @@ abstract class IEditingState {
     bool notify = true,
   });
 
+  /// Change the editing status of the currently selected cell.
+  void setEditingSelectedCell(
+    bool flag, {
+    bool notify = true,
+  });
+
   void setAutoEditing(
     bool flag, {
     bool notify = true,
@@ -113,6 +119,39 @@ mixin EditingState implements IPlutoGridState {
     _state._isEditing = flag;
 
     clearCurrentSelecting(notify: false);
+
+    notifyListeners(notify, setEditing.hashCode);
+  }
+
+  @override
+  void setEditingSelectedCell(
+    bool flag, {
+    bool notify = true,
+  }) {
+    if (!mode.isEditableMode || (flag && currentCell == null)) {
+      flag = false;
+    }
+
+    if (isEditing == flag) return;
+
+    if (flag) {
+      assert(
+        currentCell?.column != null && currentCell?.row != null,
+        """
+      PlutoCell is not Initialized. 
+      PlutoColumn and PlutoRow must be initialized in PlutoCell via PlutoGridStateManager.
+      initializeRows method. When adding or deleting columns or rows, 
+      you must use methods on PlutoGridStateManager. Otherwise, 
+      the PlutoCell is not initialized and this error occurs.
+      """,
+      );
+
+      if (!isEditableCell(currentCell!)) {
+        flag = false;
+      }
+    }
+
+    _state._isEditing = flag;
 
     notifyListeners(notify, setEditing.hashCode);
   }

--- a/test/mock/shared_mocks.mocks.dart
+++ b/test/mock/shared_mocks.mocks.dart
@@ -2248,6 +2248,20 @@ class MockPlutoGridStateManager extends _i1.Mock
       );
 
   @override
+  void setEditingSelectedCell(
+    bool? flag, {
+    bool? notify = true,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #setEditingSelectedCell,
+          [flag],
+          {#notify: notify},
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   void setAutoEditing(
     bool? flag, {
     bool? notify = true,
@@ -3532,6 +3546,38 @@ class MockPlutoGridStateManager extends _i1.Mock
       );
 
   @override
+  void selectCell(
+    _i2.PlutoColumn? column,
+    int? rowIdx,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #selectCell,
+          [
+            column,
+            rowIdx,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void unselectCell(
+    _i2.PlutoColumn? column,
+    int? rowIdx,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #unselectCell,
+          [
+            column,
+            rowIdx,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   void updateVisibilityLayout({bool? notify = false}) => super.noSuchMethod(
         Invocation.method(
           #updateVisibilityLayout,
@@ -3728,6 +3774,13 @@ class MockPlutoGridKeyPressed extends _i1.Mock
   @override
   bool get ctrl => (super.noSuchMethod(
         Invocation.getter(#ctrl),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get meta => (super.noSuchMethod(
+        Invocation.getter(#meta),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);

--- a/test/scenario/selecting/selecting_cells_by_long_tap_test.dart
+++ b/test/scenario/selecting/selecting_cells_by_long_tap_test.dart
@@ -25,10 +25,10 @@ void main() {
 
         final selected = [
           // @formatter:off
-          ['column1', 1], ['column2', 1],
-          ['column1', 2], ['column2', 2],
-          ['column1', 3], ['column2', 3],
-          ['column1', 4], ['column2', 4],
+          ['column1', 1, 1], ['column2', 1, 2],
+          ['column1', 2, 1], ['column2', 2, 2],
+          ['column1', 3, 1], ['column2', 3, 2],
+          ['column1', 4, 1], ['column2', 4, 2],
           // @formatter:on
         ];
 
@@ -42,6 +42,7 @@ void main() {
             PlutoGridSelectingCellPosition(
               field: selected[i][0] as String,
               rowIdx: selected[i][1] as int,
+              columnIdx: selected[i][2] as int,
             ),
           );
         }
@@ -59,8 +60,8 @@ void main() {
 
         final selected = [
           // @formatter:off
-          ['column1', 1], ['column2', 1],
-          ['column1', 2], ['column2', 2],
+          ['column1', 1, 1], ['column2', 1, 2],
+          ['column1', 2, 1], ['column2', 2, 2],
           // @formatter:on
         ];
 
@@ -74,6 +75,7 @@ void main() {
             PlutoGridSelectingCellPosition(
               field: selected[i][0] as String,
               rowIdx: selected[i][1] as int,
+              columnIdx: selected[i][2] as int,
             ),
           );
         }
@@ -100,8 +102,11 @@ void main() {
 
         final selected = [
           // @formatter:off
-          ['column1', 0], ['column2', 0], ['column3', 0], ['column4', 0],
-          ['column0', 1],
+          ['column1', 0, 1],
+          ['column2', 0, 2],
+          ['column3', 0, 3],
+          ['column4', 0, 4],
+          ['column0', 1, 0],
           // @formatter:on
         ];
 
@@ -115,6 +120,7 @@ void main() {
             PlutoGridSelectingCellPosition(
               field: selected[i][0] as String,
               rowIdx: selected[i][1] as int,
+              columnIdx: selected[i][2] as int,
             ),
           );
         }
@@ -132,8 +138,11 @@ void main() {
 
         final selected = [
           // @formatter:off
-          ['column1', 0], ['column2', 0], ['column3', 0], ['column4', 0],
-          ['column0', 1],
+          ['column1', 0, 1],
+          ['column2', 0, 2],
+          ['column3', 0, 3],
+          ['column4', 0, 4],
+          ['column0', 1, 0],
           // @formatter:on
         ];
 
@@ -147,6 +156,7 @@ void main() {
             PlutoGridSelectingCellPosition(
               field: selected[i][0] as String,
               rowIdx: selected[i][1] as int,
+              columnIdx: selected[i][2] as int,
             ),
           );
         }
@@ -164,7 +174,7 @@ void main() {
 
         final selected = [
           // @formatter:off
-          ['column0', 1],
+          ['column0', 1, 0],
           // @formatter:on
         ];
 
@@ -178,6 +188,7 @@ void main() {
             PlutoGridSelectingCellPosition(
               field: selected[i][0] as String,
               rowIdx: selected[i][1] as int,
+              columnIdx: selected[i][2] as int,
             ),
           );
         }
@@ -195,7 +206,8 @@ void main() {
 
         final selected = [
           // @formatter:off
-          ['column0', 1], ['column1', 1],
+          ['column0', 1, 0],
+          ['column1', 1, 1],
           // @formatter:on
         ];
 
@@ -209,6 +221,7 @@ void main() {
             PlutoGridSelectingCellPosition(
               field: selected[i][0] as String,
               rowIdx: selected[i][1] as int,
+              columnIdx: selected[i][2] as int,
             ),
           );
         }
@@ -226,7 +239,8 @@ void main() {
 
         final selected = [
           // @formatter:off
-          ['column0', 1], ['column1', 1],
+          ['column0', 1, 0],
+          ['column1', 1, 1],
           // @formatter:on
         ];
 
@@ -240,6 +254,7 @@ void main() {
             PlutoGridSelectingCellPosition(
               field: selected[i][0] as String,
               rowIdx: selected[i][1] as int,
+              columnIdx: selected[i][2] as int,
             ),
           );
         }

--- a/test/src/manager/event/pluto_grid_cell_gesture_event_test.dart
+++ b/test/src/manager/event/pluto_grid_cell_gesture_event_test.dart
@@ -92,8 +92,7 @@ void main() {
       'PlutoMode = normal, '
       'isEditing = true, '
       'Then, '
-      'setKeepFocus(true) 가 호출 되고, '
-      'setCurrentCell 이 호출 되어야 한다.',
+      'setEditing(false)',
       () {
         // given
         when(stateManager.hasFocus).thenReturn(false);
@@ -115,10 +114,7 @@ void main() {
         event.handler(stateManager);
 
         // then
-        verify(stateManager.setKeepFocus(true)).called(1);
-        verify(stateManager.setCurrentCell(cell, rowIdx)).called(1);
-        // 호출 되지 않아야 할 메소드
-        verifyNever(stateManager.setEditing(any));
+        verify(stateManager.setEditing(false)).called(1);
       },
     );
 


### PR DESCRIPTION
Using the meta key, you can now bulk edit cells by clicking on a cell, using the meta key or shift to select additional cells, then editing the initial cell's value which will update all cells within the same column. Had to fix a few tests since I added an additional instance variable to an existing class.